### PR TITLE
Fix SSN false positives and profanity detection weight

### DIFF
--- a/src/llm_shelter/validators/pii.py
+++ b/src/llm_shelter/validators/pii.py
@@ -42,7 +42,7 @@ _PHONE_US = PIIPattern(
 
 _SSN = PIIPattern(
     name="ssn",
-    pattern=re.compile(r"\b(?!000|666|9\d{2})\d{3}[\s\-]?(?!00)\d{2}[\s\-]?(?!0000)\d{4}\b"),
+    pattern=re.compile(r"\b(?!000|666|9\d{2})\d{3}[\s\-](?!00)\d{2}[\s\-](?!0000)\d{4}\b"),
     placeholder="[SSN_REDACTED]",
     severity=1.0,
 )

--- a/src/llm_shelter/validators/toxicity.py
+++ b/src/llm_shelter/validators/toxicity.py
@@ -20,7 +20,7 @@ _PROFANITY = ToxicityCategory(
     patterns=[
         re.compile(r"(?i)\b(?:fuck|shit|damn|ass|bitch|crap|dick|piss)\w*\b"),
     ],
-    weight=0.4,
+    weight=0.6,
 )
 
 _SLURS = ToxicityCategory(

--- a/tests/test_pii.py
+++ b/tests/test_pii.py
@@ -49,9 +49,15 @@ class TestSSNDetection:
         assert not result.is_valid
         assert any(f.category == "ssn" for f in result.findings)
 
-    def test_ssn_no_dashes(self, validator: PIIValidator) -> None:
+    def test_ssn_no_dashes_no_match(self, validator: PIIValidator) -> None:
+        """Bare 9-digit numbers should NOT trigger SSN detection (false positive fix)."""
         result = validator.validate("SSN: 123456789")
+        assert result.is_valid
+
+    def test_ssn_with_spaces(self, validator: PIIValidator) -> None:
+        result = validator.validate("My SSN is 123 45 6789")
         assert not result.is_valid
+        assert any(f.category == "ssn" for f in result.findings)
 
 
 class TestCreditCardDetection:


### PR DESCRIPTION
Fixes #4, fixes #5

- SSN regex now requires separator characters (dashes/spaces) to avoid matching plain 9-digit numbers like order IDs
- Profanity weight bumped from 0.4 to 0.6 so it exceeds the default 0.5 threshold